### PR TITLE
fix: avoid additional space when space key is pressed

### DIFF
--- a/src/main/resources/META-INF/frontend/fc-xterm/xterm-element.ts
+++ b/src/main/resources/META-INF/frontend/fc-xterm/xterm-element.ts
@@ -155,13 +155,7 @@ export class XTermElement extends LitElement implements TerminalMixin {
       this.customKeyEventHandlers.handle(this, ev);
       if (ev.cancelBubble) return false;
       
-      if (ev.key==' ') {
-          term.write(' ');
-          return false;
-      } else {
-          return true;
-      }
- 
+      return true; 
     });   
   }
  


### PR DESCRIPTION
The removed code seems to be a hack for circumventing some issue in version 1 of the addon (based on xterm.js 4.4.0). Version 2 is based on xterm.js 4.14.0, where that codes causes that two spaces are written each time the user presses <kbd>Space</kbd>.  All integration tests passed after removing that block.