### PR TITLE
feat: add method for enqueuing a listener before others

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -459,7 +459,7 @@
 		<profile>
 			<id>v23</id>
 			<properties>
-				<vaadin.version>23.3.5</vaadin.version>
+				<vaadin.version>23.3.6</vaadin.version>
 				<maven.compiler.source>11</maven.compiler.source>
 				<maven.compiler.target>11</maven.compiler.target>				
 			</properties>

--- a/src/main/java/com/flowingcode/vaadin/addons/xterm/ITerminal.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/xterm/ITerminal.java
@@ -2,7 +2,7 @@
  * #%L
  * XTerm Console Addon
  * %%
- * Copyright (C) 2020 - 2022 Flowing Code
+ * Copyright (C) 2020 - 2023 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/flowingcode/vaadin/addons/xterm/ITerminalClipboard.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/xterm/ITerminalClipboard.java
@@ -2,7 +2,7 @@
  * #%L
  * XTerm Console Addon
  * %%
- * Copyright (C) 2020 - 2022 Flowing Code
+ * Copyright (C) 2020 - 2023 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/flowingcode/vaadin/addons/xterm/ITerminalConsole.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/xterm/ITerminalConsole.java
@@ -2,7 +2,7 @@
  * #%L
  * XTerm Console Addon
  * %%
- * Copyright (C) 2020 - 2022 Flowing Code
+ * Copyright (C) 2020 - 2023 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/flowingcode/vaadin/addons/xterm/ITerminalFit.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/xterm/ITerminalFit.java
@@ -2,7 +2,7 @@
  * #%L
  * XTerm Console Addon
  * %%
- * Copyright (C) 2020 - 2022 Flowing Code
+ * Copyright (C) 2020 - 2023 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/flowingcode/vaadin/addons/xterm/ITerminalOptions.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/xterm/ITerminalOptions.java
@@ -2,7 +2,7 @@
  * #%L
  * XTerm Console Addon
  * %%
- * Copyright (C) 2020 - 2022 Flowing Code
+ * Copyright (C) 2020 - 2023 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/flowingcode/vaadin/addons/xterm/ITerminalSelection.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/xterm/ITerminalSelection.java
@@ -2,7 +2,7 @@
  * #%L
  * XTerm Console Addon
  * %%
- * Copyright (C) 2020 - 2022 Flowing Code
+ * Copyright (C) 2020 - 2023 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/flowingcode/vaadin/addons/xterm/PreserveStateAddon.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/xterm/PreserveStateAddon.java
@@ -2,7 +2,7 @@
  * #%L
  * XTerm Console Addon
  * %%
- * Copyright (C) 2020 - 2022 Flowing Code
+ * Copyright (C) 2020 - 2023 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/flowingcode/vaadin/addons/xterm/TerminalHistory.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/xterm/TerminalHistory.java
@@ -2,7 +2,7 @@
  * #%L
  * XTerm Console Addon
  * %%
- * Copyright (C) 2020 - 2022 Flowing Code
+ * Copyright (C) 2020 - 2023 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/flowingcode/vaadin/addons/xterm/TerminalTheme.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/xterm/TerminalTheme.java
@@ -2,7 +2,7 @@
  * #%L
  * XTerm Console Addon
  * %%
- * Copyright (C) 2020 - 2022 Flowing Code
+ * Copyright (C) 2020 - 2023 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/flowingcode/vaadin/addons/xterm/XTerm.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/xterm/XTerm.java
@@ -2,7 +2,7 @@
  * #%L
  * XTerm Console Addon
  * %%
- * Copyright (C) 2020 - 2022 Flowing Code
+ * Copyright (C) 2020 - 2023 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/flowingcode/vaadin/addons/xterm/XTermBase.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/xterm/XTermBase.java
@@ -2,7 +2,7 @@
  * #%L
  * XTerm Console Addon
  * %%
- * Copyright (C) 2020 - 2022 Flowing Code
+ * Copyright (C) 2020 - 2023 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/flowingcode/vaadin/addons/xterm/utils/StateMemoizer.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/xterm/utils/StateMemoizer.java
@@ -2,7 +2,7 @@
  * #%L
  * XTerm Console Addon
  * %%
- * Copyright (C) 2020 - 2022 Flowing Code
+ * Copyright (C) 2020 - 2023 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/resources/META-INF/frontend/fc-xterm/xterm-clipboard-mixin.ts
+++ b/src/main/resources/META-INF/frontend/fc-xterm/xterm-clipboard-mixin.ts
@@ -2,7 +2,7 @@
  * #%L
  * XTerm Console Addon
  * %%
- * Copyright (C) 2020 - 2022 Flowing Code
+ * Copyright (C) 2020 - 2023 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/resources/META-INF/frontend/fc-xterm/xterm-console-mixin.ts
+++ b/src/main/resources/META-INF/frontend/fc-xterm/xterm-console-mixin.ts
@@ -2,7 +2,7 @@
  * #%L
  * XTerm Console Addon
  * %%
- * Copyright (C) 2020 - 2022 Flowing Code
+ * Copyright (C) 2020 - 2023 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/resources/META-INF/frontend/fc-xterm/xterm-element.ts
+++ b/src/main/resources/META-INF/frontend/fc-xterm/xterm-element.ts
@@ -2,7 +2,7 @@
  * #%L
  * XTerm Console Addon
  * %%
- * Copyright (C) 2020 - 2022 Flowing Code
+ * Copyright (C) 2020 - 2023 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/resources/META-INF/frontend/fc-xterm/xterm-element.ts
+++ b/src/main/resources/META-INF/frontend/fc-xterm/xterm-element.ts
@@ -161,6 +161,11 @@ export class XTermElement extends LitElement implements TerminalMixin {
     this.bellStyle = 'none';
   }
 
+  _onData(e:string) : void {
+    //<N CSI is handled by console-feature
+    this.terminal.write(e.replace(/\r/g,'\x1b[<N\n'));
+  }
+  
   connectedCallback() {
     super.connectedCallback();
 
@@ -168,10 +173,7 @@ export class XTermElement extends LitElement implements TerminalMixin {
     term.options.convertEol = true;
     
     //onLineFeed doesn't distinguish lines from user input and lines from terminal.write
-    //<N CSI is handled by console-feature
-    term.onData(e => {
-        term.write(e.replace(/\r/g,'\x1b[<N\n'));
-    });
+    term.onData(e=>this._onData(e));
     
     term.onBell(() => {
       if (this.bellStyle == 'sound') {

--- a/src/main/resources/META-INF/frontend/fc-xterm/xterm-fit-mixin.ts
+++ b/src/main/resources/META-INF/frontend/fc-xterm/xterm-fit-mixin.ts
@@ -2,7 +2,7 @@
  * #%L
  * XTerm Console Addon
  * %%
- * Copyright (C) 2020 - 2022 Flowing Code
+ * Copyright (C) 2020 - 2023 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/resources/META-INF/frontend/fc-xterm/xterm-insertfix-mixin.ts
+++ b/src/main/resources/META-INF/frontend/fc-xterm/xterm-insertfix-mixin.ts
@@ -2,7 +2,7 @@
  * #%L
  * XTerm Console Addon
  * %%
- * Copyright (C) 2020 - 2022 Flowing Code
+ * Copyright (C) 2020 - 2023 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/resources/META-INF/frontend/fc-xterm/xterm-selection-mixin.ts
+++ b/src/main/resources/META-INF/frontend/fc-xterm/xterm-selection-mixin.ts
@@ -2,7 +2,7 @@
  * #%L
  * XTerm Selection Addon
  * %%
- * Copyright (C) 2020 - 2022 Flowing Code
+ * Copyright (C) 2020 - 2023 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/resources/META-INF/frontend/fc-xterm/xterm.ts
+++ b/src/main/resources/META-INF/frontend/fc-xterm/xterm.ts
@@ -2,7 +2,7 @@
  * #%L
  * XTerm Console Addon
  * %%
- * Copyright (C) 2020 - 2022 Flowing Code
+ * Copyright (C) 2020 - 2023 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/flowingcode/vaadin/addons/DemoLayout.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/DemoLayout.java
@@ -2,7 +2,7 @@
  * #%L
  * XTerm Console Addon
  * %%
- * Copyright (C) 2020 - 2022 Flowing Code
+ * Copyright (C) 2020 - 2023 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/flowingcode/vaadin/addons/xterm/DemoView.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/xterm/DemoView.java
@@ -2,7 +2,7 @@
  * #%L
  * XTerm Console Addon
  * %%
- * Copyright (C) 2020 - 2022 Flowing Code
+ * Copyright (C) 2020 - 2023 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/flowingcode/vaadin/addons/xterm/PreserveStateAddonTest.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/xterm/PreserveStateAddonTest.java
@@ -2,7 +2,7 @@
  * #%L
  * XTerm Console Addon
  * %%
- * Copyright (C) 2020 - 2022 Flowing Code
+ * Copyright (C) 2020 - 2023 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/flowingcode/vaadin/addons/xterm/XtermDemoView.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/xterm/XtermDemoView.java
@@ -2,7 +2,7 @@
  * #%L
  * XTerm Console Addon
  * %%
- * Copyright (C) 2020 - 2022 Flowing Code
+ * Copyright (C) 2020 - 2023 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/flowingcode/vaadin/addons/xterm/integration/AbstractViewTest.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/xterm/integration/AbstractViewTest.java
@@ -2,7 +2,7 @@
  * #%L
  * XTerm Console Addon
  * %%
- * Copyright (C) 2020 - 2022 Flowing Code
+ * Copyright (C) 2020 - 2023 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/flowingcode/vaadin/addons/xterm/integration/ClipboardFeatureIT.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/xterm/integration/ClipboardFeatureIT.java
@@ -2,7 +2,7 @@
  * #%L
  * XTerm Console Addon
  * %%
- * Copyright (C) 2020 - 2022 Flowing Code
+ * Copyright (C) 2020 - 2023 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/flowingcode/vaadin/addons/xterm/integration/ConsoleFeatureIT.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/xterm/integration/ConsoleFeatureIT.java
@@ -2,7 +2,7 @@
  * #%L
  * XTerm Console Addon
  * %%
- * Copyright (C) 2020 - 2022 Flowing Code
+ * Copyright (C) 2020 - 2023 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/flowingcode/vaadin/addons/xterm/integration/FitFeatureIT.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/xterm/integration/FitFeatureIT.java
@@ -2,7 +2,7 @@
  * #%L
  * XTerm Console Addon
  * %%
- * Copyright (C) 2020 - 2022 Flowing Code
+ * Copyright (C) 2020 - 2023 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/flowingcode/vaadin/addons/xterm/integration/Position.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/xterm/integration/Position.java
@@ -2,7 +2,7 @@
  * #%L
  * XTerm Console Addon
  * %%
- * Copyright (C) 2020 - 2022 Flowing Code
+ * Copyright (C) 2020 - 2023 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/flowingcode/vaadin/addons/xterm/integration/SelectionFeatureIT.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/xterm/integration/SelectionFeatureIT.java
@@ -2,7 +2,7 @@
  * #%L
  * XTerm Console Addon
  * %%
- * Copyright (C) 2020 - 2022 Flowing Code
+ * Copyright (C) 2020 - 2023 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/flowingcode/vaadin/addons/xterm/integration/TerminalHistoryIT.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/xterm/integration/TerminalHistoryIT.java
@@ -2,7 +2,7 @@
  * #%L
  * XTerm Console Addon
  * %%
- * Copyright (C) 2020 - 2022 Flowing Code
+ * Copyright (C) 2020 - 2023 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/flowingcode/vaadin/addons/xterm/integration/XTermElement.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/xterm/integration/XTermElement.java
@@ -2,7 +2,7 @@
  * #%L
  * XTerm Console Addon
  * %%
- * Copyright (C) 2020 - 2022 Flowing Code
+ * Copyright (C) 2020 - 2023 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/flowingcode/vaadin/addons/xterm/integration/XTermIT.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/xterm/integration/XTermIT.java
@@ -2,7 +2,7 @@
  * #%L
  * XTerm Console Addon
  * %%
- * Copyright (C) 2020 - 2022 Flowing Code
+ * Copyright (C) 2020 - 2023 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/flowingcode/vaadin/addons/xterm/integration/XTermTestUtils.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/xterm/integration/XTermTestUtils.java
@@ -2,7 +2,7 @@
  * #%L
  * XTerm Console Addon
  * %%
- * Copyright (C) 2020 - 2022 Flowing Code
+ * Copyright (C) 2020 - 2023 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/flowingcode/vaadin/addons/xterm/test/SerializationTest.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/xterm/test/SerializationTest.java
@@ -2,7 +2,7 @@
  * #%L
  * XTerm Console Addon
  * %%
- * Copyright (C) 2020 - 2022 Flowing Code
+ * Copyright (C) 2020 - 2023 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/flowingcode/vaadin/addons/xterm/utils/StateMemoizerTest.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/xterm/utils/StateMemoizerTest.java
@@ -2,7 +2,7 @@
  * #%L
  * XTerm Console Addon
  * %%
- * Copyright (C) 2020 - 2022 Flowing Code
+ * Copyright (C) 2020 - 2023 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
[feat: add method for enqueuing a listener before others](https://github.com/FlowingCode/XTermConsoleAddon/commit/fc0ab7a1f8b57a1d45990ee74db0173581659ff7) 

By default, custom key listeners execute in the same order they were registered. In some cases, it's desirable to add a listener that executes before others, so that it can prevent the event from propagating, so that the event is not handled by other listeners that have been added earlier..

Also [refactor: move onData callback to method](https://github.com/FlowingCode/XTermConsoleAddon/commit/f6967b51c60e14cfc424fdcf9520561797bc5441) and [ci: upgrade Vaadin 23 version to 23.3.6](https://github.com/FlowingCode/XTermConsoleAddon/commit/20b8c0c34f7e800792639f4d5227ce704b646309) and [chore: update license headers](https://github.com/FlowingCode/XTermConsoleAddon/commit/f54e76ec0c2b9eb2b884dc1b60eadea880d9e6a0)