### PR TITLE
feat: add support for named terminal add-ons

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.flowingcode.addons</groupId>
     <artifactId>xterm-console</artifactId>
-    <version>3.1.1-SNAPSHOT</version>
+    <version>3.2.0-SNAPSHOT</version>
     <name>XTerm Console Addon</name>
     <description>Integration of xterm.js for Vaadin Flow</description>
 

--- a/src/main/java/com/flowingcode/vaadin/addons/xterm/ClientTerminalAddon.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/xterm/ClientTerminalAddon.java
@@ -1,0 +1,106 @@
+/*-
+ * #%L
+ * XTerm Console Addon
+ * %%
+ * Copyright (C) 2020 - 2025 Flowing Code
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.flowingcode.vaadin.addons.xterm;
+
+import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.internal.JsonCodec;
+import elemental.json.Json;
+import elemental.json.JsonArray;
+import java.io.Serializable;
+
+/**
+ * Represents an abstract base class for server-side terminal add-ons that have a corresponding
+ * client-side (JavaScript) component or require interaction with the client-side terminal
+ * environment. It extends {@link TerminalAddon} and specializes its use for client-aware
+ * operations.
+ *
+ * @author Javier Godoy / Flowing Code S.A.
+ */
+@SuppressWarnings("serial")
+public abstract class ClientTerminalAddon extends TerminalAddon {
+
+  private final XTermBase xterm;
+
+  /**
+   * Constructs a new {@code ClientTerminalAddon} and associates it with the specified
+   * {@link XTermBase} instance.
+   * <p>
+   * This constructor ensures the add-on is registered with the terminal and verifies that the
+   * add-on's name, as returned by {@link #getName()}, is not {@code null}. A non-null name is
+   * required for client-side add-ons to be uniquely identified and targeted for JavaScript
+   * execution.
+   * </p>
+   *
+   * @param xterm the {@link XTermBase} instance this add-on will be attached to. Must not be
+   *        {@code null}.
+   * @throws NullPointerException if {@code xterm} is {@code null}
+   * @throws IllegalStateException if {@link #getName()} returns {@code null} immediately after
+   *         superclass construction. This check relies on {@code getName()} being a static value.
+   */
+  protected ClientTerminalAddon(XTermBase xterm) {
+    super(xterm);
+    this.xterm = xterm;
+    if (getName() == null) {
+      throw new IllegalStateException("getName() must return a non-null value");
+    }
+  }
+
+  /**
+   * The xterm instance that this add-on is associated with.
+   */
+  protected XTermBase getXterm() {
+    return xterm;
+  }
+
+  /**
+   * Retrieves the unique name of this client-side add-on.
+   * <p>
+   * This name is used by {@link #executeJs(String, Serializable...)} to target the corresponding
+   * JavaScript object on the client (i.e., {@code this.addons[name]} within the client-side
+   * terminal's scope). The name effectively acts as a key in a client-side add-ons collection
+   * managed by the terminal.
+   * </p>
+   *
+   * @return the unique, non-null string identifier for the client-side counterpart of this add-on.
+   *         Subclasses must implement this to provide a name for add-on-specific JavaScript
+   *         execution.
+   */
+  protected abstract String getName();
+
+  /**
+   * Executes a JavaScript {@code expression} in the context of this add-on, with the specified
+   * {@code parameters}.
+   *
+   * @see #getName()
+   * @see Element#executeJs(String, Serializable...)
+   */
+  protected final void executeJs(String expression, Serializable... parameters) {
+    String name = getName();
+
+    JsonArray args = Json.createArray();
+    for (int i = 0; i < parameters.length; i++) {
+      args.set(i, JsonCodec.encodeWithTypeInfo(parameters[i]));
+    }
+
+    expression = expression.replaceAll("\\$(\\d+)", "\\$1[$1]");
+    xterm.executeJs("(function(){" + expression + "}).apply(this.addons[$0],$1);", name, args);
+  }
+
+}

--- a/src/main/java/com/flowingcode/vaadin/addons/xterm/PreserveStateAddon.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/xterm/PreserveStateAddon.java
@@ -2,7 +2,7 @@
  * #%L
  * XTerm Console Addon
  * %%
- * Copyright (C) 2020 - 2023 Flowing Code
+ * Copyright (C) 2020 - 2025 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,7 +43,9 @@ import java.util.concurrent.CompletableFuture;
  * addon.writePrompt();
  * </pre>
  */
-public class PreserveStateAddon implements ITerminal, ITerminalOptions {
+public class PreserveStateAddon extends TerminalAddon
+    implements ITerminal, ITerminalOptions {
+
     /**
      * The xterm to delegate all calls to.
      */
@@ -80,6 +82,7 @@ public class PreserveStateAddon implements ITerminal, ITerminalOptions {
     private final ITerminalOptions optionsDelegate;
 
     public PreserveStateAddon(XTerm xterm) {
+        super(xterm);
         this.xterm = Objects.requireNonNull(xterm);
         optionsMemoizer = new StateMemoizer(xterm, ITerminalOptions.class);
         optionsDelegate = (ITerminalOptions) optionsMemoizer.getProxy();

--- a/src/main/java/com/flowingcode/vaadin/addons/xterm/TerminalAddon.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/xterm/TerminalAddon.java
@@ -1,0 +1,51 @@
+/*-
+ * #%L
+ * XTerm Console Addon
+ * %%
+ * Copyright (C) 2020 - 2025 Flowing Code
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.flowingcode.vaadin.addons.xterm;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ * Represents an abstract base class for server-side add-ons designed to extend or modify the
+ * functionality of an {@link XTermBase} terminal instance.
+ * <p>
+ * Concrete add-on implementations should subclass this class to provide specific features. Each
+ * add-on is tightly coupled with a specific {@code XTermBase} instance, allowing it to interact
+ * with and enhance that terminal.
+ * </p>
+ *
+ * @author Javier Godoy / Flowing Code S.A.
+ */
+@SuppressWarnings("serial")
+public abstract class TerminalAddon implements Serializable {
+
+  /**
+   * Constructs a new {@code TerminalAddon} and associates it with the provided {@link XTermBase}
+   * instance.
+   *
+   * @param xterm the {@code XTermBase} instance to which this add-on will be attached
+   * @throws NullPointerException if the provided {@code xterm} is {@code null}
+   */
+  protected TerminalAddon(XTermBase xterm) {
+    Objects.requireNonNull(xterm);
+    xterm.registerServerSideAddon(this);
+  }
+
+}

--- a/src/main/resources/META-INF/frontend/fc-xterm/xterm-element.ts
+++ b/src/main/resources/META-INF/frontend/fc-xterm/xterm-element.ts
@@ -161,6 +161,8 @@ export class XTermElement extends LitElement implements TerminalMixin {
   bellStyle: 'none' | 'sound'
   
   customKeyEventHandlers: CustomKeyEventHandlerRegistry;
+  
+  addons : Object = {};
 
   render(): TemplateResult {
     return html`


### PR DESCRIPTION
**Related Issue:** #98

This pull request provides a mechanism for server-side retrieval of add-on instances. While it doesn't automate the entire add-on setup process, it's a foundational step towards better overall add-on management.

**Expectation:**
> Also most add-ons come with their object that exposes settings of the add-on. While I consider this a bonus, it would of course be great if somehow these settings objects could be exposed as Java objects."

The `getAddon()` method indirectly supports this expectation, contingent on add-on design. 
By calling `xterm.getAddon(MySpecificAddon.class)`, developers can retrieve the server-side Java instance of `MySpecificAddon`. If this `MySpecificAddon` class is designed to hold, manage, or provide access to its settings (which might mirror client-side settings or be purely server-side), then this PR enables to access those settings via methods defined on the `MySpecificAddon` Java object (e.g., `customAddon.getSettings()`, `customAddon.getSomeSpecificSetting()`).

The `getAddon()` method itself does not automatically create or map client-side JavaScript settings objects into new Java objects if such a mapping isn't already part of the server-side add-on's own implementation. It provides the *server-side add-on object*; how that object exposes or interacts with settings is determined by the add-on's specific design.

In essence, this PR provides a foundational piece for server-side add-on interaction, which can be leveraged for accessing settings if the add-ons are designed to expose them through their server-side Java API. The automation of client-side loading and direct mapping of purely client-side settings objects are considered out of scope for this particular change but could potentially build upon the mechanism introduced here.

**Usage Example:**
```
@NpmPackage(value = "@xterm/addon-web-links", version = "0.11.0")
@JsModule("./fc-xterm/xterm-weblinks-addon.ts")
public class WebLinkAddon extends ClientTerminalAddon {

  private final static String NAME = "addon-web-links";

  public WebLinkAddon(XTermBase xterm) {
    super(xterm);
    xterm.getElement().executeJs("Vaadin.Flow.fcXtermConnector.load_weblinks($0, this)", NAME);
  }

  public void setFoo(String foo) {
    executeJs("this.foo=$0;", foo);
  }

  @Override
  public String getName() {
    return NAME;
  }

}
```


```
import { WebLinksAddon } from '@xterm/addon-web-links';
import { XTermElement } from './xterm-element';

(function () { 
  (window as any).Vaadin.Flow.fcXtermConnector = (window as any).Vaadin.Flow.fcXtermConnector || {};
  (window as any).Vaadin.Flow.fcXtermConnector.load_weblinks = (name:string, node: XTermElement) => {
    const addon = new WebLinksAddon();
    node.terminal.loadAddon(addon);
    node.addons[name]=addon;
  };
})();
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced support for server-side terminal add-ons, enabling enhanced interactions and extensions for the terminal component.
  - Added a mechanism to manage and register add-ons associated with each terminal instance.
  - Provided the ability for add-ons to execute JavaScript code on the client-side terminal.
  - Added a new property to manage add-ons within the client-side terminal element.

- **Other Changes**
  - Updated copyright years.
  - Internal version number incremented.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->